### PR TITLE
Tracking of busy carts and cart requirements

### DIFF
--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -14,6 +14,10 @@ function rowColorChanger(numRoutes) {
 			//put this route's id into the form
 			$('#trip_cart_route_id').attr('value', $(this).attr('id')[$(this).attr('id').length - 1]);
 			
+			//put the associated route into the form.
+			//TODO get the actual cart ID.
+			$('#trip_cart_id').attr('value', "1");
+			
 			//display the "start trip" button
 			$('#startTrip').slideDown("slow");
 		});

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -5,24 +5,23 @@ class TripsController < ApplicationController
     end
     
     def new
-        @cartRoutes = CartRoute.all
-        @trip = Trip.new
-        @trip.save
-        
         cutoff = DateTime.current - 5.minutes
         Cart.all.each do |cart|
             if (cart.inUse)
                 if (cart.last_busy_check < cutoff)
                     cart.inUse = false
                     cart.save
-                else
-                    #@cartRoutes.reject(|r| cart.)
-                    #//TODO dont show routes for carts that are busy
                 end
             end
         end
-        @carts = Cart.where(inUse: false)
         
+        #@carts = Cart.where(inUse: false)
+        @carts = Cart.all
+        
+        @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false})
+        
+        @trip = Trip.new
+        @trip.save
         
     end
     

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -15,10 +15,18 @@ class TripsController < ApplicationController
             end
         end
         
-        #@carts = Cart.where(inUse: false)
-        @carts = Cart.all
+        max_seats = 10
+        if params.has_key?(:seat_count)
+            min = params[:seat_count].to_i
+            if (min < 1)
+                min = 1
+            end
+           seats = [min .. max_seats] 
+        else
+            seats = [1..max_seats]
+        end
         
-        @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false})
+        @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false}).where(:carts => {:seat_count => seats})
         
         @trip = Trip.new
         @trip.save

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -26,7 +26,18 @@ class TripsController < ApplicationController
             seats = [1..max_seats]
         end
         
-        @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false}).where(:carts => {:seat_count => seats})
+        if params.has_key?(:handicap_access)
+            needs_assist = params[:handicap_access].to_s == "on"
+        else
+            needs_assist = false
+        end
+        
+        if needs_assist
+            @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false}).where(:carts => {:seat_count => seats}).where(:carts => {:handicap_access => true})
+        else
+            @cartRoutes = CartRoute.joins(:cart).where(:carts => {:inUse => false}).where(:carts => {:seat_count => seats})
+        end
+        
         
         @trip = Trip.new
         @trip.save

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -15,9 +15,14 @@ class TripsController < ApplicationController
                 if (cart.last_busy_check < cutoff)
                     cart.inUse = false
                     cart.save
+                else
+                    #@cartRoutes.reject(|r| cart.)
+                    #//TODO dont show routes for carts that are busy
                 end
             end
         end
+        @carts = Cart.where(inUse: false)
+        
         
     end
     

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -8,6 +8,17 @@ class TripsController < ApplicationController
         @cartRoutes = CartRoute.all
         @trip = Trip.new
         @trip.save
+        
+        cutoff = DateTime.current - 5.minutes
+        Cart.all.each do |cart|
+            if (cart.inUse)
+                if (cart.last_busy_check < cutoff)
+                    cart.inUse = false
+                    cart.save
+                end
+            end
+        end
+        
     end
     
     def specify
@@ -19,6 +30,18 @@ class TripsController < ApplicationController
         @trip.cart_route = CartRoute.find(params[:trip][:cart_route_id])
         #put trip id in session in case user accidently closes tab
         session[:trip_id] = @trip.id
+        
+        #Mark the cart as busy with a timestamp
+        currentCart = Cart.where(cart_id: params[:trip][:cart_id])
+        if currentCart.exists?
+            currentCart = currentCart.first
+            currentCart.inUse = true
+            currentCart.last_busy_check = DateTime.current
+            currentCart.save
+        else
+            redirect_to '/new'
+        end
+        
         redirect_to '/pickup'
     end
     

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,2 +1,3 @@
 class Cart < ApplicationRecord
+    has_many :cart_route, dependent: :destroy
 end

--- a/app/models/cart_route.rb
+++ b/app/models/cart_route.rb
@@ -1,3 +1,4 @@
 class CartRoute < ApplicationRecord
     has_many :coordinates
+    belongs_to :cart, optional: true
 end

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -38,6 +38,9 @@
         <div style="display:none">
           <%= form.text_field :cart_route_id, :id => 'trip_cart_route_id' %>
         </div>
+        <div style="display:none">
+          <%= form.text_field :cart_id, :id => 'trip_cart_id' %>
+        </div>
       </div>
       
     </table>

--- a/db/migrate/20180424061123_cart_busy_tracking.rb
+++ b/db/migrate/20180424061123_cart_busy_tracking.rb
@@ -2,7 +2,6 @@ class CartBusyTracking < ActiveRecord::Migration[5.1]
   def change
     change_table :carts do |t|
       t.datetime :last_busy_check
-      t.integer :cart_id
     end
   end
 end

--- a/db/migrate/20180424061123_cart_busy_tracking.rb
+++ b/db/migrate/20180424061123_cart_busy_tracking.rb
@@ -1,0 +1,8 @@
+class CartBusyTracking < ActiveRecord::Migration[5.1]
+  def change
+    change_table :carts do |t|
+      t.datetime :last_busy_check
+      t.integer :cart_id
+    end
+  end
+end

--- a/db/migrate/20180424080304_cart_route_map.rb
+++ b/db/migrate/20180424080304_cart_route_map.rb
@@ -1,0 +1,7 @@
+class CartRouteMap < ActiveRecord::Migration[5.1]
+  def change
+    change_table :cart_routes do |t|
+      t.integer :cart_id, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424061123) do
+ActiveRecord::Schema.define(version: 20180424080304) do
 
   create_table "cart_routes", force: :cascade do |t|
     t.decimal "length"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20180424061123) do
     t.integer "trip_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "cart_id"
     t.index ["trip_id"], name: "index_cart_routes_on_trip_id"
   end
 
@@ -31,8 +32,8 @@ ActiveRecord::Schema.define(version: 20180424061123) do
     t.datetime "updated_at", null: false
     t.integer "seat_count"
     t.boolean "handicap_access"
-    t.datetime "last_busy_check"
     t.integer "cart_id"
+    t.datetime "last_busy_check"
     t.index ["trip_id"], name: "index_carts_on_trip_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305185607) do
+ActiveRecord::Schema.define(version: 20180424061123) do
 
   create_table "cart_routes", force: :cascade do |t|
     t.decimal "length"
     t.string "startPoint"
     t.string "endPoint"
+    t.integer "cart_route_id"
     t.integer "trip_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -28,6 +29,10 @@ ActiveRecord::Schema.define(version: 20180305185607) do
     t.integer "trip_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "seat_count"
+    t.boolean "handicap_access"
+    t.datetime "last_busy_check"
+    t.integer "cart_id"
     t.index ["trip_id"], name: "index_carts_on_trip_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,3 +21,9 @@ coordinates = [{:lat => 30.621284, :lng => -96.340388, :cart_route => CartRoute.
 coordinates.each do |coordinate|
   Coordinate.create!(coordinate)
 end
+
+carts = [{:IP => 0, :inUse => false, :trip_id => -1, :seat_count => 6, :handicap_access => true, :last_busy_check => 0, :cart_id => 1}]
+
+carts.each do |cart|
+  Cart.create!(cart)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ coordinates.each do |coordinate|
   Coordinate.create!(coordinate)
 end
 
-carts = [{:IP => 0, :inUse => false, :trip_id => -1, :seat_count => 6, :handicap_access => true, :last_busy_check => 0, :cart_id => 1}]
+carts = [{:IP => 0, :inUse => false, :trip_id => -1, :seat_count => 6, :handicap_access => false, :last_busy_check => 0, :cart_id => 1}]
 
 carts.each do |cart|
   Cart.create!(cart)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-cart_routes = [{:length => 9.99, :startPoint => 'Cyclotron Institute', :endPoint => 'HRBB', :cart_route_id => 1},
-                {:length => 9.99, :startPoint => 'Engineering Innovation Center', :endPoint => 'Evans Library', :cart_route_id => 2}]
+cart_routes = [{:length => 9.99, :startPoint => 'Cyclotron Institute', :endPoint => 'HRBB', :cart_route_id => 1, :cart_id => 1},
+                {:length => 9.99, :startPoint => 'Engineering Innovation Center', :endPoint => 'Evans Library', :cart_route_id => 2, :cart_id => 1}]
 
 cart_routes.each do |cart_route|
   CartRoute.create!(cart_route)


### PR DESCRIPTION
Carts are marked busy when a route is started, and don't show up until they haven't been interacted with for 5 minutes. Also carts have seats and handicap access associated with them, and only routes belonging to carts that fulfill the specifications show up when searching for a route.